### PR TITLE
BetamaxError MonkeyPatch na Spy

### DIFF
--- a/tests_web/conftest.py
+++ b/tests_web/conftest.py
@@ -172,5 +172,9 @@ def client_maker(betamax_session, utils, monkeypatch):
 
     # Check number of created BetamaxErrors
     # You should catch only your/specific exceptions
-    assert utils.BETAMAX_ERRORS == 0, \
-        'There were some BetamaxErrors (although you might have caught them)!'
+    try:
+        assert utils.BETAMAX_ERRORS == 0, \
+            'There were some BetamaxErrors (although you might ' \
+            'have caught them)!'
+    finally:
+        Utils.BETAMAX_ERRORS = 0


### PR DESCRIPTION
Ověření, zda se byly vytvořeny instance `BetamaxError` bez ohledu na to, jestli je třeba někdo nechytil ve své implementaci (fix pro issue #12).

Ještě by šlo si `BetamaxError` uložit a pak vyhodit z `conftest`... 