### PR TITLE
Update tests_module to upgrade setuptools

### DIFF
--- a/tests_module/conftest.py
+++ b/tests_module/conftest.py
@@ -81,6 +81,7 @@ class Utils:
         result = self.sh(self.create_venv)
         assert result.was_successful, \
             'Could not create virtualenv for Python: {}'.format(result.stderr)
+        self.sh(self.python, '-m', 'pip', 'install', '--upgrade', 'setuptools')
 
     def clone_repo(self, repo_dir):
         result = self.sh(self.git, 'clone', '-b', self.repo_branch, self.repo_ssh, repo_dir)


### PR DESCRIPTION
When creating a virtual environment, the bundled setuptools version which gets
used may be quite old.  This can cause problems for packages which use a
setup.cfg file.  This commit updates the potentially affected tests to upgrade
setuptools before they attempt to interact with the user provided package.