### PR TITLE
Add conversion to string and change comparision from > to >=

### DIFF
--- a/tests_module/test_submodules.py
+++ b/tests_module/test_submodules.py
@@ -9,21 +9,21 @@ def test_submodules(utils, tmpdir):
     utils.clone_repo_with_fresh_venv(repo_dir)
 
     # Check the content of repository (Python module "labelord")
-    content = os.listdir(tmpdir.join(repo_dir))
+    content = os.listdir(str(tmpdir.join(repo_dir)))
     assert 'labelord' in content, \
         'No "labelord" entry in the repository'
 
-    assert os.path.isdir(tmpdir.join(repo_dir).join('labelord')), \
+    assert os.path.isdir(str(tmpdir.join(repo_dir).join('labelord'))), \
         'Entry "labelord" is not a directory'
 
-    content = os.listdir(tmpdir.join(repo_dir).join('labelord'))
+    content = os.listdir(str(tmpdir.join(repo_dir).join('labelord')))
 
     assert '__init__.py' in content, \
         'Labelord is not a module (no __init__.py file)'
     assert '__main__.py' in content, \
         'Labelord is not runnable (no __main__.py file)'
     pyfiles = [f for f in content if f.endswith('.py')]
-    assert len(pyfiles) > 5, \
+    assert len(pyfiles) >= 5, \
         'There are less than 3 submodules (additional .py files in module)'
     assert 'templates' in content, \
         'No templates (for web app) in the module'


### PR DESCRIPTION
Maybe i found some mistakes in test for setup part. First problem is that os.listdir and os.isdir need String or Binary, but can not work with LocalPath class (tested on python 3.5.2). So i added string conversion.

Second change is in comparsion of number of modules. In task we need to implement at least 3 modules, so there should be >= 5 comparsion i think (__main__.py, __init__.py, and 3 files). 

So i think, this should be correct

Thanks